### PR TITLE
Use configurable logging to generate success and failure output only whe...

### DIFF
--- a/dnsmadeeasy/update_ddns_dnsmadeeasy.py
+++ b/dnsmadeeasy/update_ddns_dnsmadeeasy.py
@@ -15,30 +15,39 @@ from __future__ import print_function
 
 import socket
 import json
+import logging
 import os
 import sys
 import requests
 import dns.resolver
 
+logging.basicConfig(format='%(levelname)s: %(message)s')
 
-def error(*objs):
-    print("ERROR:", *objs, file=sys.stderr)
+logger = logging.getLogger(__name__)
+
+
+def error(message):
+    """
+    Log an error and exit.
+    """
+    logger.error(message)
     sys.exit(1)
 
 
 def check_ssl(url):
     try:
         requests.get(url, verify=True)
-        return True
     except requests.exceptions.SSLError:
-        return error('The SSL certificate for {0} is not valid.'.format(url))
+        error('The SSL certificate for {0} is not valid.'.format(url))
 
 
 def get_current_ip(url=None):
     url = url or GET_IP_URL
-    r = requests.get(url)
-    ip = r.text.strip()
-    return ip
+    try:
+        return requests.get(url).text.strip()
+    except requests.ConnectionError:
+        logger.debug(
+            'Could not get the current IP from {0}'.format(GET_IP_URL))
 
 
 def get_dns_ip(name=None, target='A'):
@@ -56,14 +65,12 @@ def get_dns_ip(name=None, target='A'):
             q = resolver.query(name, target)
             ip = str(q[0]).strip()
             return ip
+    error('Could not get the authoritative name server for {0}.'.format(name))
 
 
-def update_ip_to_dns(ip=False, url=None):
+def update_ip_to_dns(ip, url=None):
     url = url or UPDATE_IP_URL
-    if not ip:
-        return error('Could not determine the current IP.')
-    if not check_ssl(url):
-        return False
+    check_ssl(url)
     params = {
         'username': USERNAME,
         'password': PASSWORD,
@@ -91,25 +98,31 @@ RECORD_NAME = settings.get('RECORD_NAME', None)
 GET_IP_URL = settings.get('GET_IP_URL', 'http://www.dnsmadeeasy.com/myip.jsp')
 UPDATE_IP_URL = settings.get('UPDATE_IP_URL',
                              'https://www.dnsmadeeasy.com/servlet/updateip')
-QUIET = settings.get('QUIET', False)
+LOG_LEVEL = settings.get('LOG_LEVEL', 'INFO')
 
 for opt in 'USERNAME', 'PASSWORD', 'RECORD_ID', 'RECORD_NAME':
     if not locals().get(opt):
         error('Missing `{0}` setting. Check `settings.json` file.'.format(opt))
 
+try:
+    logger.setLevel(getattr(logging, LOG_LEVEL))
+except AttributeError:
+    error('Invalid `LOG_LEVEL` setting. Check `settings.json` file. Valid '
+          'log levels are: DEBUG, INFO, WARNING, ERROR, CRITICAL.')
+
 if __name__ == '__main__':
     current_ip = get_current_ip()
-    ip_in_dns = get_dns_ip()
-    if current_ip != ip_in_dns:
-        print('Current IP differs with DNS record, attempting to update DNS.')
-        request = update_ip_to_dns(current_ip)
-        if request and request.text == 'success':
-            msg = 'Updating record for {0} to {1} was succesful'.format(
-                RECORD_NAME, current_ip)
-            print(msg)
+    if current_ip:
+        if current_ip != get_dns_ip():
+            logger.debug('Current IP differs with DNS record, attempting to '
+                         'update DNS.')
+            request = update_ip_to_dns(current_ip)
+            if request and request.text == 'success':
+                logger.info('Updating record for {0} to {1} was '
+                            'succesful.'.format(RECORD_NAME, current_ip))
+            else:
+                error('Updating record for {0} to {1} failed.'.format(
+                    RECORD_NAME, current_ip))
         else:
-            msg = 'Updating record for {0} to {1} failed.'.format(
-                RECORD_NAME, current_ip)
-            error(msg)
-    elif not QUIET:
-        print('No changes for DNS record {0} to report.'.format(RECORD_NAME))
+            logger.debug(
+                'No changes for DNS record {0} to report.'.format(RECORD_NAME))


### PR DESCRIPTION
...n an update is actually attempted.

Log ERROR messages on misconfiguration or failure when an update
attempt is made, an INFO message on success, and DEBUG messages for
everything else.

If we can't get the current IP due to connection error, assume
connection is unavailable and do nothing.

Allows users reduce verbosity when run from cron, to avoid sending
non-essential emails, or increase it when testing.

Remove redundant return statements from `check_ssl(). If the certificate
is not valid, `sys.exit()` gets called. If it is valid, we don't need to
return anything.

Remove default value (`False`) from `ip` argument to `update_ip_to_dns`
function. This function does not attempt to determine the current IP,
and the failure to do so is logged elsewhere.